### PR TITLE
fix appeared caption on gallery image open

### DIFF
--- a/components/content/Gallery.vue
+++ b/components/content/Gallery.vue
@@ -42,7 +42,6 @@ watch(openedPhoto, () => {
 </script>
 
 <template>
-   {{openedPhoto}}
   <div class="gallery">
     <Photo
        v-for="([src, caption], i) in data"


### PR DESCRIPTION
При открытии фото в галерее появлялась подпись
![image](https://github.com/user-attachments/assets/8e3c5cdb-0b13-4686-a821-b3feb05600e4)
