### PR TITLE
move category filter to separate component

### DIFF
--- a/common/constants.ts
+++ b/common/constants.ts
@@ -3,3 +3,24 @@ export enum ArticleType {
     WithSubCategories,
     SubCategory,
 }
+
+export enum FilterTypeKeys {
+    ByCategory = '0',
+    ByDate = '1',
+}
+
+export const FilterTypeParams = {
+    [FilterTypeKeys.ByCategory]: 'filter_category',
+    [FilterTypeKeys.ByDate]: 'filter_date',
+}
+
+export enum FilterDateKeys {
+    ASC = '0',
+    DESC = '1',
+}
+
+export const FilterDateParams = {
+    [FilterDateKeys.ASC]: 'filter_asc',
+    [FilterDateKeys.DESC]: 'filter_desc',
+}
+

--- a/common/types.ts
+++ b/common/types.ts
@@ -56,3 +56,8 @@ export interface Product {
   components: ProductOption[];
   use_cases: string[];
 }
+
+type Url = string;
+type Title = string;
+type Cover = string;
+export type Video = [Url, Title, Cover];

--- a/components/Article.vue
+++ b/components/Article.vue
@@ -48,10 +48,13 @@ const to = props.url || `${route.path}${route.path.at(-1) === '/' ? '' : '/'}${p
   object-fit: cover;
   border: 1px solid var(--gray-color);
   min-height: 125px;
+  flex-shrink: 0;
 
   @media (min-width: 400px) and (max-width: 940px) {
-    width: 220px;
-    height: auto;
+    width: 100%;
+    max-width: 220px;
+    height: 100%;
+    max-height: 126px;
   }
 
   @media (max-width: 460px) {

--- a/components/CategoryFilter.vue
+++ b/components/CategoryFilter.vue
@@ -1,0 +1,106 @@
+<script setup lang="ts">
+import SelectButton from '~/components/SelectButton.vue';
+import { FilterTypeKeys, FilterDateParams, FilterTypeParams } from '~/common/constants';
+import type { Categories } from '~/common/types';
+
+const props = defineProps<{ pageId?: string; categories: Categories }>();
+
+const { t, locale } = useI18n();
+const filterTypes = Object.entries(FilterTypeParams).map(([value, label]) => ({ value, label: t(label) }));
+const filterDates = Object.entries(FilterDateParams).map(([value, label]) => ({ value, label: t(label) }));
+const filter = defineModel('filter');
+const filterDate = defineModel('filterDate');
+
+watch(() => filter.value, () => {
+  if (props.pageId) {
+    console.log(1)
+    scrollToElementById(props.pageId);
+  }
+})
+</script>
+
+<template>
+  <div class="categoryFilter">
+    <SelectButton v-model="filter" :options="filterTypes as any" optionLabel="label" optionValue="value" />
+    <div class="categoryFilter-content">
+      <ul v-if="filter === FilterTypeKeys.ByCategory">
+        <li v-for="category in categories[locale]" :key="category.name">
+          <div @click="scrollToElementById(category.name)">{{ category.label }}</div>
+          <ul v-if="category.sub_category">
+            <li v-for="subCategory in category.sub_category" :key="category.name">
+              <div @click="scrollToElementById(subCategory.name)">{{ subCategory.label }}</div>
+            </li>
+          </ul>
+        </li>
+      </ul>
+      <div v-else>
+        <div v-for="filter in filterDates" :key="filter.label" class="categoryFilter-date">
+          <RadioButton v-model="filterDate" :inputId="filter.label" :value="filter.value" />
+          <label :for="filter.label" class="ml-2">{{ filter.label }}</label>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+
+.categoryFilter {
+  position: sticky;
+  top: 16px;
+  min-width: 310px;
+}
+
+.categoryFilter-content {
+  margin-top: 12px;
+}
+
+.categoryFilter ul {
+  margin: 0;
+  padding-left: 24px;
+  color: var(--link-color);
+}
+
+.categoryFilter li::marker {
+  color: var(--text-color);
+}
+
+.categoryFilter ul ul {
+  padding-left: 22px;
+}
+
+.categoryFilter ul li div {
+  width: fit-content;
+}
+
+.categoryFilter ul li div:hover {
+  cursor: pointer;
+  text-decoration: underline;
+}
+
+.categoryFilter-date {
+  display: flex;
+  gap: 4px;
+}
+
+.categoryFilter-date label {
+  cursor: pointer;
+}
+</style>
+
+<i18n>
+{
+  "ru": {
+    "filter_category": "По категориям",
+    "filter_date": "По дате публикации",
+    "filter_asc": "Сначала новые",
+    "filter_desc": "Сначала старые"
+  },
+  "en": {
+    "filter_category": "By category",
+    "filter_date": "By date",
+    "filter_asc": "New ones first",
+    "filter_desc": "Old ones first"
+  }
+}
+</i18n>

--- a/components/content/VideoGallery.vue
+++ b/components/content/VideoGallery.vue
@@ -1,10 +1,6 @@
 <script setup lang="ts">
 import VideoPlayer from './VideoPlayer.vue';
-
-type Url = string;
-type Title = string;
-type Cover = string;
-type Video = [Url, Title, Cover];
+import type { Video } from '~/common/types';
 
 defineProps<{ data: Video[]; }>();
 </script>

--- a/pages/contents/articles/index.vue
+++ b/pages/contents/articles/index.vue
@@ -1,7 +1,6 @@
 <script lang="ts" setup>
 import { categories } from '~/common/article_categories';
-import { ArticleType } from '~/common/constants';
-import SelectButton from '~/components/SelectButton.vue';
+import { ArticleType, FilterDateParams, FilterTypeKeys, FilterTypeParams } from '~/common/constants';
 import type { QueryBuilderParams } from '@nuxt/content';
 
 const { t, locale } = useI18n();
@@ -11,10 +10,8 @@ useHead({
   title: t('title'),
 });
 
-const filter = ref(t('filter_category'));
-const filterDate = ref('filter_asc');
-const options = ref([t('filter_category'), t('filter_date')]);
-const filterDates = ['filter_asc', 'filter_desc'];
+const filter = ref(Object.keys(FilterTypeParams).at(0));
+const filterDate = ref(Object.keys(FilterDateParams).at(0));
 
 const query: QueryBuilderParams = { path: '/_articles', where: [{ _locale: locale.value }] }
 const { data } = await useAsyncData('articles', () => queryContent(query.path).where({ _locale: locale.value }).find());
@@ -28,8 +25,8 @@ if (!data.value?.length) {
 </script>
 
 <template>
-  <div class="articles page-content">
-    <div v-if="filter === 'По категориям'" class="articles-content">
+  <div class="articles page-content" id="articles">
+    <div v-if="filter === FilterTypeKeys.ByCategory" class="articles-content">
       <template v-for="(category, i) in flattenCategories(categories, locale)" :key="category.name">
         <h3
           v-if="category.type === ArticleType.SubCategory"
@@ -45,7 +42,7 @@ if (!data.value?.length) {
         </h2>
 
         <div class="articles-list" v-if="data!.filter((item) => item.category === category.name).length">
-          <Article v-bind="article as any" v-for="article in data!.filter((item) => item.category === category.name).sort((a, b) => new Date(b.date) - new Date(a.date) )" :key="article._path" />
+          <Article v-bind="article as any" v-for="article in getFilteredByCategory(data, category)" :key="article._path" />
         </div>
 
         <hr v-if="category.type !== ArticleType.WithSubCategories && i !== flattenCategories(categories, locale).length - 1" class="articles-separator" />
@@ -54,33 +51,12 @@ if (!data.value?.length) {
 
     <div v-else class="articles-content">
       <div class="articles-list">
-        <Article v-bind="article as any" v-for="article in data!.sort((a, b) => filterDate === 'filter_asc' ? new Date(b.date) - new Date(a.date) : new Date(a.date) - new Date(b.date) )" :key="article._path" />
+        <Article v-bind="article as any" v-for="article in getFilteredByDate(data, filterDate)" :key="article._path" />
       </div>
     </div>
 
     <aside class="sidebar">
-      <div class="articles-filter">
-        <SelectButton v-model="filter" :options="options" />
-
-        <div class="articles-filterContent">
-          <ul v-if="filter === 'По категориям'">
-            <li v-for="category in categories[locale]" :key="category.name">
-              <div @click="scrollToElementById(category.name)">{{ category.label }}</div>
-              <ul v-if="category.sub_category">
-                <li v-for="category in category.sub_category" :key="category.name">
-                  <div @click="scrollToElementById(category.name)">{{ category.label }}</div>
-                </li>
-              </ul>
-            </li>
-          </ul>
-          <div v-else>
-            <div v-for="filter in filterDates" :key="filter" class="articles-filterDate">
-              <RadioButton v-model="filterDate" :inputId="filter" :value="filter" />
-              <label :for="filter" class="ml-2">{{ t(filter) }}</label>
-            </div>
-          </div>
-        </div>
-      </div>
+      <CategoryFilter :categories="categories" v-model:filter="filter" v-model:filter-date="filterDate" page-id="articles" />
     </aside>
   </div>
 </template>
@@ -155,64 +131,15 @@ h3.articles-title {
 .articles-separator {
   margin: 24px 0;
 }
-
-.articles-filter {
-  position: sticky;
-  top: 16px;
-}
-
-.articles-filterContent {
-  margin-top: 12px;
-}
-
-.articles-filter ul {
-  margin: 0;
-  padding-left: 24px;
-  color: var(--link-color);
-}
-
-.articles-filter li::marker {
-  color: var(--text-color);
-}
-
-.articles-filter ul ul {
-  padding-left: 22px;
-}
-
-.articles-filter ul li div {
-  width: fit-content;
-}
-
-.articles-filter ul li div:hover {
-  cursor: pointer;
-  text-decoration: underline;
-}
-
-.articles-filterDate {
-  display: flex;
-  gap: 4px;
-}
-
-.articles-filterDate label {
-  cursor: pointer;
-}
 </style>
 
 <i18n>
 {
   "ru": {
-    "title": "Статьи",
-    "filter_category": "По категориям",
-    "filter_date": "По дате публикации",
-    "filter_asc": "Сначала новые",
-    "filter_desc": "Сначала старые"
+    "title": "Статьи"
   },
   "en": {
-    "title": "Articles",
-    "filter_category": "By category",
-    "filter_date": "By date",
-    "filter_asc": "New ones first",
-    "filter_desc": "Old ones first"
+    "title": "Articles"
   }
 }
 </i18n>

--- a/pages/contents/solutions/index.vue
+++ b/pages/contents/solutions/index.vue
@@ -1,8 +1,7 @@
 <script lang="ts" setup>
 import type { QueryBuilderParams } from '@nuxt/content';
 import { categories } from '~/common/solution_categories';
-import { ArticleType } from '~/common/constants';
-import SelectButton from '~/components/SelectButton.vue';
+import { ArticleType, FilterDateParams, FilterTypeKeys, FilterTypeParams } from '~/common/constants';
 
 const { t, locale } = useI18n();
 const route = useRoute();
@@ -11,10 +10,8 @@ useHead({
   title: t('title'),
 });
 
-const filter = ref(t('filter_category'));
-const filterDate = ref('filter_asc');
-const options = ref([t('filter_category'), t('filter_date')]);
-const filterDates = ['filter_asc', 'filter_desc'];
+const filter = ref(Object.keys(FilterTypeParams).at(0));
+const filterDate = ref(Object.keys(FilterDateParams).at(0));
 
 const query: QueryBuilderParams = { path: '/_solutions', where: [{ _locale: locale.value }] }
 const { data } = await useAsyncData('solutions', () => queryContent(query.path).where({ _locale: locale.value }).find());
@@ -28,65 +25,44 @@ if (!data.value?.length) {
 </script>
 
 <template>
-  <div class="articles page-content">
-    <div v-if="filter === 'По категориям'" class="articles-content">
+  <div class="solutions page-content" id="solutions">
+    <div v-if="filter === FilterTypeKeys.ByCategory" class="solutions-content">
       <template v-for="(category, i) in flattenCategories(categories, locale)" :key="category.name">
         <h3
           v-if="category.type === ArticleType.SubCategory"
-          class="articles-title"
+          class="solutions-title"
           :id="category.name">
           <a :href="`#${category.name}`">{{ category.label }}</a>
         </h3>
         <h2
           v-else
-          class="articles-title"
+          class="solutions-title"
           :id="category.name">
           <a :href="`#${category.name}`">{{ category.label }}</a>
         </h2>
 
-        <div class="articles-list" v-if="data!.filter((item) => item.category === category.name).length">
-          <Article v-bind="article as any" v-for="article in data!.filter((item) => item.category === category.name).sort((a, b) => new Date(b.date) - new Date(a.date) )" :key="article._path" />
+        <div class="solutions-list" v-if="data!.filter((item) => item.category === category.name).length">
+          <Article v-bind="article as any" v-for="article in getFilteredByCategory(data, category)" :key="article._path" />
         </div>
 
-        <hr v-if="category.type !== ArticleType.WithSubCategories && i !== flattenCategories(categories, locale).length - 1" class="articles-separator" />
+        <hr v-if="category.type !== ArticleType.WithSubCategories && i !== flattenCategories(categories, locale).length - 1" class="solutions-separator" />
       </template>
     </div>
 
-    <div v-else class="articles-content">
-      <div class="articles-list">
-        <Article v-bind="article as any" v-for="article in data.sort((a, b) => filterDate === 'filter_asc' ? new Date(b.date) - new Date(a.date) : new Date(a.date) - new Date(b.date) )" :key="article._path" />
+    <div v-else class="solutions-content">
+      <div class="solutions-list">
+        <Article v-bind="article as any" v-for="article in getFilteredByDate(data, filterDate)" :key="article._path" />
       </div>
     </div>
 
     <aside class="sidebar">
-      <div class="articles-filter">
-        <SelectButton v-model="filter" :options="options" />
-
-        <div class="articles-filterContent">
-          <ul v-if="filter === 'По категориям'">
-            <li v-for="category in categories[locale]" :key="category.name">
-              <div @click="scrollToElementById(category.name)">{{ category.label }}</div>
-              <ul v-if="category.sub_category">
-                <li v-for="category in category.sub_category" :key="category.name">
-                  <div @click="scrollToElementById(category.name)">{{ category.label }}</div>
-                </li>
-              </ul>
-            </li>
-          </ul>
-          <div v-else>
-            <div v-for="filter in filterDates" :key="filter" class="articles-filterDate">
-              <RadioButton v-model="filterDate" :inputId="filter" :value="filter" />
-              <label :for="filter" class="ml-2">{{ t(filter) }}</label>
-            </div>
-          </div>
-        </div>
-      </div>
+      <CategoryFilter :categories="categories" v-model:filter="filter" v-model:filter-date="filterDate" page-id="solutions" />
     </aside>
   </div>
 </template>
 
 <style>
-.articles {
+.solutions {
   display: flex;
   gap: 48px;
 
@@ -96,48 +72,48 @@ if (!data.value?.length) {
   }
 }
 
-.articles-content {
+.solutions-content {
   flex-grow: 1;
 }
 
-.articles-title {
+.solutions-title {
   line-height: normal;
   scroll-margin-top: var(--app-bar-height);
 }
 
-.articles-title:first-child {
+.solutions-title:first-child {
   margin-top: 0;
 }
 
-h2.articles-title {
+h2.solutions-title {
   font-size: 27px;
 }
 
-h3.articles-title {
+h3.solutions-title {
   font-size: 21px;
 }
 
-.articles-title a {
+.solutions-title a {
   color: var(--text-color);
 }
 
-.articles-title a:hover {
+.solutions-title a:hover {
   color: var(--link-color);
 }
 
-.articles-title a:hover::before {
+.solutions-title a:hover::before {
   content: '#';
   position: absolute;
   margin-left: -18px;
 }
 
 @media (max-width: 1340px) {
-  .articles-title a:hover::before {
+  .solutions-title a:hover::before {
     content: '';
   }
 }
 
-.articles-list {
+.solutions-list {
   display: grid;
   grid-template-columns: 1fr 1fr 1fr;
   gap: 32px;
@@ -152,67 +128,18 @@ h3.articles-title {
   }
 }
 
-.articles-separator {
+.solutions-separator {
   margin: 24px 0;
-}
-
-.articles-filter {
-  position: sticky;
-  top: 16px;
-}
-
-.articles-filterContent {
-  margin-top: 12px;
-}
-
-.articles-filter ul {
-  margin: 0;
-  padding-left: 24px;
-  color: var(--link-color);
-}
-
-.articles-filter li::marker {
-  color: var(--text-color);
-}
-
-.articles-filter ul ul {
-  padding-left: 22px;
-}
-
-.articles-filter ul li div {
-  width: fit-content;
-}
-
-.articles-filter ul li div:hover {
-  cursor: pointer;
-  text-decoration: underline;
-}
-
-.articles-filterDate {
-  display: flex;
-  gap: 4px;
-}
-
-.articles-filterDate label {
-  cursor: pointer;
 }
 </style>
 
 <i18n>
 {
   "ru": {
-    "title": "Примеры внедрений",
-    "filter_category": "По категориям",
-    "filter_date": "По дате публикации",
-    "filter_asc": "Сначала новые",
-    "filter_desc": "Сначала старые"
+    "title": "Примеры внедрений"
   },
   "en": {
-    "title": "Solutions",
-    "filter_category": "By category",
-    "filter_date": "By date",
-    "filter_asc": "New ones first",
-    "filter_desc": "Old ones first"
+    "title": "Solutions"
   }
 }
 </i18n>

--- a/pages/contents/video.vue
+++ b/pages/contents/video.vue
@@ -1,9 +1,9 @@
 <script lang="ts" setup>
 import type { QueryBuilderParams } from '@nuxt/content';
 import { videoCategories } from '~/common/video_categories';
-import { ArticleType } from '~/common/constants';
-import SelectButton from '~/components/SelectButton.vue';
+import { ArticleType, FilterDateParams, FilterTypeKeys, FilterTypeParams } from '~/common/constants';
 import VideoGallery from '~/components/content/VideoGallery.vue';
+import type { Video } from '~/common/types';
 
 const { t, locale } = useI18n();
 const route = useRoute();
@@ -12,10 +12,8 @@ useHead({
   title: t('title'),
 });
 
-const filter = ref(t('filter_category'));
-const filterDate = ref('filter_asc');
-const options = ref([t('filter_category'), t('filter_date')]);
-const filterDates = ['filter_asc', 'filter_desc'];
+const filter = ref(Object.keys(FilterTypeParams).at(0));
+const filterDate = ref(Object.keys(FilterDateParams).at(0));
 
 const query: QueryBuilderParams = { path: '/_video', where: [{ _locale: locale.value }] };
 const { data } = await useAsyncData('video', () => queryContent(query.path).where({ _locale: locale.value }).find());
@@ -28,20 +26,11 @@ if (!data.value?.length) {
 }
 
 const flattenedCategories = computed(() => flattenCategories(videoCategories, locale.value));
-
-const getFinalData = (videos) => {
-  const sorted = (a, b) => filter.value !== 'По категориям' && filterDate.value === 'filter_asc'
-    ? new Date(b.date) - new Date(a.date)
-    : new Date(a.date) - new Date(b.date);
-
-  return videos.sort(sorted)
-    .map(video => [video.url, video.title, video.cover]);
-};
 </script>
 
 <template>
-  <div class="video page-content">
-    <div v-if="filter === 'По категориям'">
+  <div class="video page-content" id="video">
+    <div v-if="filter === FilterTypeKeys.ByCategory">
       <template v-for="(category, i) in flattenedCategories" :key="category.name">
         <h3
           v-if="category.type === ArticleType.SubCategory"
@@ -56,37 +45,16 @@ const getFinalData = (videos) => {
           <a :href="`#${category.name}`">{{ category.label }}</a>
         </h2>
 
-        <VideoGallery :data="getFinalData(data!.filter((item) => item.category === category.name))" />
+        <VideoGallery :data="getFilteredByCategory(data, category).map(video => [video.url, video.title, video.cover]) as Video[]" />
 
         <hr v-if="category.type !== ArticleType.WithSubCategories && i !== flattenedCategories.length - 1" class="video-separator" />
       </template>
     </div>
 
-    <VideoGallery v-else :data="getFinalData(data)" />
+    <VideoGallery v-else :data="getFilteredByDate(data, filterDate).map(video => [video.url, video.title, video.cover]) as Video[]" />
 
     <aside class="sidebar">
-      <div class="video-filter">
-        <SelectButton v-model="filter" :options="options" />
-
-        <div class="video-filterContent">
-          <ul v-if="filter === 'По категориям'">
-            <li v-for="category in videoCategories[locale]" :key="category.name">
-              <div @click="scrollToElementById(category.name)">{{ category.label }}</div>
-              <ul v-if="category.sub_category">
-                <li v-for="category in category.sub_category" :key="category.name">
-                  <div @click="scrollToElementById(category.name)">{{ category.label }}</div>
-                </li>
-              </ul>
-            </li>
-          </ul>
-          <div v-else>
-            <div v-for="filter in filterDates" :key="filter" class="video-filterDate">
-              <RadioButton v-model="filterDate" :inputId="filter" :value="filter" />
-              <label :for="filter" class="ml-2">{{ t(filter) }}</label>
-            </div>
-          </div>
-        </div>
-      </div>
+      <CategoryFilter :categories="videoCategories" v-model:filter="filter" v-model:filter-date="filterDate" page-id="video" />
     </aside>
   </div>
 </template>
@@ -142,64 +110,15 @@ h3.video-title {
 .video-separator {
   margin: 24px 0;
 }
-
-.video-filter {
-  position: sticky;
-  top: 16px;
-}
-
-.video-filterContent {
-  margin-top: 12px;
-}
-
-.video-filter ul {
-  margin: 0;
-  padding-left: 24px;
-  color: var(--link-color);
-}
-
-.video-filter li::marker {
-  color: var(--text-color);
-}
-
-.video-filter ul ul {
-  padding-left: 22px;
-}
-
-.video-filter ul li div {
-  width: fit-content;
-}
-
-.video-filter ul li div:hover {
-  cursor: pointer;
-  text-decoration: underline;
-}
-
-.video-filterDate {
-  display: flex;
-  gap: 4px;
-}
-
-.video-filterDate label {
-  cursor: pointer;
-}
 </style>
 
 <i18n>
 {
   "ru": {
-    "title": "Видео",
-    "filter_category": "По категориям",
-    "filter_date": "По дате публикации",
-    "filter_asc": "Сначала новые",
-    "filter_desc": "Сначала старые"
+    "title": "Видео"
   },
   "en": {
-    "title": "Video",
-    "filter_category": "By category",
-    "filter_date": "By date",
-    "filter_asc": "New ones first",
-    "filter_desc": "Old ones first"
+    "title": "Video"
   }
 }
 </i18n>

--- a/utils/filteredData.ts
+++ b/utils/filteredData.ts
@@ -1,0 +1,11 @@
+import type { ParsedContent } from '@nuxt/content';
+import { FilterDateKeys } from '~/common/constants';
+import type { Category } from '~/common/types';
+
+export const getFilteredByCategory = (data: ParsedContent[] | null, category: Category) => data!
+  .filter((item) => item.category === category.name)
+  .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
+
+export const getFilteredByDate = (data: ParsedContent[] | null, dateFilter?: string) => data!
+  .sort((a, b) => dateFilter === FilterDateKeys.ASC
+    ? new Date(b.date).getTime() - new Date(a.date).getTime() : new Date(a.date).getTime() - new Date(b.date).getTime() )


### PR DESCRIPTION
Вынес фильтр по категориям в отдельный компонент (было 3 страницы с одинаковым фильтром и логикой фильтрации).
Починил локализацию фильтров.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced advanced filtering capabilities for articles, solutions, and video content
	- Added category and date-based filtering options

- **Improvements**
	- Enhanced component modularity with a new `CategoryFilter` component
	- Streamlined filtering logic across multiple pages
	- Improved type definitions for video-related content

- **Technical Updates**
	- Centralized filter-related constants and type definitions
	- Updated type imports and prop definitions
	- Refined responsive styling for article covers

<!-- end of auto-generated comment: release notes by coderabbit.ai -->