### PR TITLE
Добавил страницу навигации при локальном запуске сайта

### DIFF
--- a/content/index.md
+++ b/content/index.md
@@ -1,0 +1,24 @@
+# Навигатор
+
+Русское:
+- [Статьи](http://localhost:3000/ru/contents/articles)
+- [Внедрения](http://localhost:3000/ru/contents/solutions)
+- [Работа](http://localhost:3000/ru/contents/jobs)
+- [Партнёры](http://localhost:3000/ru/contents/partners)
+- [Интеграторы](http://localhost:3000/ru/contents/integrators)
+- [Видео](http://localhost:3000/ru/contents/video)
+- Произвольные страницы — http://localhost:3000/ru/contents/FILENAME
+
+
+Английское:
+- [Articles](http://localhost:3000/en/contents/articles)
+- [Solutions](http://localhost:3000/en/contents/solutions)
+- [Jobs](http://localhost:3000/en/contents/jobs)
+- [Partners](http://localhost:3000/en/contents/partners)
+- [Integrators](http://localhost:3000/en/contents/integrators)
+- [Video](http://localhost:3000/en/contents/video)
+- Arbitrary pages — http://localhost:3000/en/contents/FILENAME
+
+Полезное:
+- [Документация в Гитхабе](https://github.com/wirenboard/website/blob/main/README.md)
+- [Ссылка на продакшн сайт](https://wirenboard.com)

--- a/content/ru/index.md
+++ b/content/ru/index.md
@@ -1,3 +1,0 @@
-# Home
-
-It works!


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
- Добавил страницу навигации в папку content, нужно при локальном просмотре, чтобы не гадать куда переходить для предпросмотра.
- Удалил файлик content/ru/index.md — вроде без него работает, Виктор, глянь.

___________________________________
**Что поменялось для пользователей:**
Для редакторов сайта стало удобно — открыл http://localhost:3000/ и видно сразу все разделы.

___________________________________
**Как проверял/а:**
Запустил сайт локально, покликал по ссылкам.

![изображение](https://github.com/user-attachments/assets/e6480642-7547-429d-bf76-fa6110830efd)

___________________________________
**Чеклист ревью:**

Перед мержем не забудь проверить:

<!-- можно добавить свои пункты, но не удалять существующие -->
<!-- если нужно добавить какие-то пункты навсегда,
     это делается в файле .github/pull_request_template.md -->

- [ ] правописание в тексте, опечатки

Опционально (но важно для изменений в инфраструктуру):

- [ ] задеплоить на stage, чтобы проверить, что все работает
