### PR TITLE
SOFT-5641

### DIFF
--- a/modules/parse-inlined-images/image-path-transformer.ts
+++ b/modules/parse-inlined-images/image-path-transformer.ts
@@ -1,0 +1,29 @@
+import { defineTransformer } from '@nuxt/content/transformers';
+import type { ParsedContent, MarkdownNode } from '@nuxt/content';
+
+export default defineTransformer({
+  name: 'image-path-transformer',
+  extensions: ['.md'],
+  transform(content: ParsedContent) {
+    const match = content._id.match(/^content:(\w+):catalog/);
+    const lang = match?.[1];
+
+    if (lang && content.body) {
+      parse(content.body, lang);
+    }
+
+    return content;
+  }
+});
+
+function parse(node: MarkdownNode, lang: string) {
+  if (Array.isArray(node.children)) {
+    for (const child of node.children) {
+      if ((child.tag === 'photo' || child.tag === 'img') && child.props?.src && !child.props.src.startsWith('/img')) {
+        child.props.src = `${lang}/catalog/${child.props.src}`;
+      }
+
+      parse(child, lang);
+    }
+  }
+}

--- a/modules/parse-inlined-images/parse-inlined-images.ts
+++ b/modules/parse-inlined-images/parse-inlined-images.ts
@@ -1,0 +1,14 @@
+import { resolve } from 'path';
+import { defineNuxtModule } from '@nuxt/kit';
+
+export default defineNuxtModule({
+  setup (_options, nuxt) {
+    nuxt.options.nitro.externals = nuxt.options.nitro.externals || {};
+    nuxt.options.nitro.externals.inline = nuxt.options.nitro.externals.inline || [];
+    nuxt.options.nitro.externals.inline.push(resolve('./parse-inlined-images'));
+    nuxt.hook('content:context', (contentContext) => {
+      contentContext.transformers.push(resolve('./modules/parse-inlined-images/image-path-transformer.ts'));
+    })
+  }
+});
+

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,3 +1,5 @@
+import ParseInlinedImages from './modules/parse-inlined-images/parse-inlined-images';
+
 // https://nuxt.com/docs/api/configuration/nuxt-config
 export default defineNuxtConfig({
   ssr: true,
@@ -16,6 +18,7 @@ export default defineNuxtConfig({
     '~/assets/css/fonts.css',
   ],
   modules: [
+    ParseInlinedImages,
     '@nuxt/content',
     '@nuxt/image',
     '@nuxtjs/i18n',

--- a/utils/imageUrl.ts
+++ b/utils/imageUrl.ts
@@ -33,7 +33,7 @@ export const getImageUrl = (url?: string) => {
   if (parentTree.includes('Page')) {
     folder = 'pages';
   } else if (parentTree.includes('Product')) {
-    folder = 'catalog';
+    return url;
   } else if (parentTree.includes('Video')) {
     if (url.startsWith('/ru') || url.startsWith('/en')) {
       return url;
@@ -41,5 +41,5 @@ export const getImageUrl = (url?: string) => {
     folder = 'video';
   }
 
-  return `${locale.value}/${folder}/${url}`
+  return `${locale.value}/${folder}/${url}`;
 };


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
Картинки по относительным путям не отображались в каталоге. Происходило это из-за вложенности в компоненты (плагин nuxt-content-assets не умел смотреть так далеко).

___________________________________
**Что поменялось для пользователей:**


___________________________________
**Как проверял/а:**
локально и на стейдже

___________________________________
**Чеклист ревью:**

Перед мержем не забудь проверить:

<!-- можно добавить свои пункты, но не удалять существующие -->
<!-- если нужно добавить какие-то пункты навсегда,
     это делается в файле .github/pull_request_template.md -->

- [ ] правописание в тексте, опечатки

Опционально (но важно для изменений в инфраструктуру):

- [ ] задеплоить на stage, чтобы проверить, что все работает
