### PR TITLE
Send X-Internal-Api-Key on server-side API calls (WB-2026-015)

### DIFF
--- a/composables/useApi.ts
+++ b/composables/useApi.ts
@@ -20,6 +20,12 @@ export const useApi = async <T>(
     if (cookieHeader) {
       headers['Cookie'] = cookieHeader;
     }
+    // WB-2026-015: identify this server-side call as coming from the trusted Nuxt renderer.
+    // The Yii product endpoint is gated on this key so it can't be reached from the public
+    // internet. Only added server-side — the browser must never see the secret.
+    if (config.internalApiKey) {
+      headers['X-Internal-Api-Key'] = config.internalApiKey as string;
+    }
   } else {
     if (config.public.siteLogin) {
       headers['Authorization'] = `Basic ${btoa(`${config.public.siteLogin}:${config.public.sitePassword}`)}`;

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -10,6 +10,9 @@ export default defineNuxtConfig({
     apiUrl: process.env.NUXT_API_URL,
     siteLogin: process.env.NUXT_SITE_LOGIN,
     sitePassword: process.env.NUXT_SITE_PASSWORD,
+    // WB-2026-015: server-only shared secret for the internal product endpoint.
+    // Deliberately NOT under `public` — it must never be shipped to the browser.
+    internalApiKey: process.env.NUXT_INTERNAL_API_KEY,
     public: {
       apiUrl: process.env.NUXT_API_URL,
       siteLogin: process.env.NUXT_SITE_LOGIN,


### PR DESCRIPTION
The Yii product endpoint (/ng/api/v1/product) is gated to internal callers. Add a server-only runtimeConfig.internalApiKey (from NUXT_INTERNAL_API_KEY, never exposed to the client) and attach it as X-Internal-Api-Key on server-side useApi requests, so the Nuxt renderer can reach the endpoint while the public internet cannot. Browser-side calls never carry the secret and never need it (product data is fetched server-side).

___________________________________
**Что происходит; кому и зачем нужно:**


___________________________________
**Что поменялось для пользователей:**


___________________________________
**Как проверял/а:**


___________________________________
**Чеклист ревью:**

Перед мержем не забудь проверить:

<!-- можно добавить свои пункты, но не удалять существующие -->
<!-- если нужно добавить какие-то пункты навсегда,
     это делается в файле .github/pull_request_template.md -->

- [ ] правописание в тексте, опечатки

Опционально (но важно для изменений в инфраструктуру):

- [ ] задеплоить на stage, чтобы проверить, что все работает
