### PR TITLE
Убрать вариант с сертификатом Минцифры из предупреждения об оплате картой

### DIFF
--- a/components/order/Payment.vue
+++ b/components/order/Payment.vue
@@ -42,9 +42,6 @@ watch(paymentMethods, (methods) => {
         <template #link>
           <a href="https://ria.ru/20260804/brauzery-2108832797.html" target="_blank" rel="noopener">{{ t('cardWarningLink') }}</a>
         </template>
-        <template #certLink>
-          <a href="https://www.gosuslugi.ru/crt" target="_blank" rel="noopener">{{ t('cardWarningCertLink') }}</a>
-        </template>
       </i18n-t>
     </p>
   </div>
@@ -82,9 +79,8 @@ watch(paymentMethods, (methods) => {
     "cardComment": "Visa / Mastercard / МИР",
     "requisites": "Банковским переводом",
     "requisitesComment": "По реквизитам",
-    "cardWarning": "К сожалению, из-за отзыва сертификатов {link}. Для того чтобы оплатить заказ по карте, выберите на следующем шаге оплату по QR-коду, или установите в своем браузере {certLink}, или оформите заказ в Яндекс Браузере. Приносим свои извинения, мы сделаем все возможное для решения проблемы.",
-    "cardWarningLink": "некоторые браузеры ограничивают доступ к оплате по карте",
-    "cardWarningCertLink": "сертификат Минцифры"
+    "cardWarning": "К сожалению, из-за отзыва сертификатов {link}. Для того чтобы оплатить заказ по карте, выберите на следующем шаге оплату по QR-коду, либо оформите заказ в Яндекс Браузере. Приносим свои извинения, мы сделаем все возможное для решения проблемы.",
+    "cardWarningLink": "некоторые браузеры ограничивают доступ к оплате по карте"
   },
   "en": {
     "title": "Select a payment method",
@@ -94,9 +90,8 @@ watch(paymentMethods, (methods) => {
     "cardComment": "Visa / Mastercard / MIR",
     "requisites": "By bank transfer",
     "requisitesComment": "Using bank details",
-    "cardWarning": "Unfortunately, due to certificate revocation, {link}. To pay for your order by card, select QR code payment at the next step, or install the {certLink} in your browser, or place your order using Yandex Browser. We apologize for the inconvenience and are doing our best to resolve the issue.",
-    "cardWarningLink": "some browsers restrict access to card payments",
-    "cardWarningCertLink": "Ministry of Digital Development certificate"
+    "cardWarning": "Unfortunately, due to certificate revocation, {link}. To pay for your order by card, select QR code payment at the next step, or place your order using Yandex Browser. We apologize for the inconvenience and are doing our best to resolve the issue.",
+    "cardWarningLink": "some browsers restrict access to card payments"
   }
 }
 </i18n>


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**

Из предупреждения об оплате картой (добавлено в #515) убираем вариант с установкой сертификата Минцифры.

___________________________________
**Что поменялось для пользователей:**

В предупреждении на странице оформления заказа остаются два варианта: оплата по QR-коду или оформление заказа в Яндекс Браузере. Ссылка на gosuslugi.ru/crt удалена (русский и английский тексты).

___________________________________
**Как проверял/а:**

Изменение только в строках i18n и разметке ссылки, шаблон предупреждения не менялся; lint контента проходит на pre-commit.

___________________________________
**Чеклист ревью:**

Перед мержем не забудь проверить:

<!-- можно добавить свои пункты, но не удалять существующие -->
<!-- если нужно добавить какие-то пункты навсегда,
     это делается в файле .github/pull_request_template.md -->

- [ ] правописание в тексте, опечатки

Опционально (но важно для изменений в инфраструктуру):

- [ ] задеплоить на stage, чтобы проверить, что все работает
