### PR TITLE
Fix delivery/payment method icon distortion in Safari

### DIFF
--- a/components/order/Select.vue
+++ b/components/order/Select.vue
@@ -88,7 +88,7 @@ const modelValue = defineModel<string>();
 
 .orderSelect-itemImg {
   width: 24px;
-  height: fit-content;
+  height: auto;
 }
 
 @media (max-width: 768px) {


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**

В Safari иконки способов доставки/оплаты на странице заказа отрисовывались искажёнными: Safari не переносит aspect ratio картинки при `height: fit-content` на `<img>`, поэтому иконка получала натуральную высоту при ширине 24px. Заменено на `height: auto`.

___________________________________
**Что поменялось для пользователей:**

Иконки в карточках выбора доставки/оплаты в Safari больше не растянуты.

___________________________________
**Как проверял/а:**

иишкой делала скриншоты разных браузеров

___________________________________
**Чеклист ревью:**

Перед мержем не забудь проверить:

<!-- можно добавить свои пункты, но не удалять существующие -->
<!-- если нужно добавить какие-то пункты навсегда,
     это делается в файле .github/pull_request_template.md -->

- [ ] правописание в тексте, опечатки

Опционально (но важно для изменений в инфраструктуру):

- [ ] задеплоить на stage, чтобы проверить, что все работает
